### PR TITLE
Make !rank command not cycle through 11 of the previous year's ranks.

### DIFF
--- a/ViolastroBot/Commands/RankModule.cs
+++ b/ViolastroBot/Commands/RankModule.cs
@@ -29,7 +29,7 @@ public sealed class RankModule : ModuleBase<SocketCommandContext>
             rankText = "Rank";
         }
 
-        ulong seed = id + (ulong)month + (ulong)year;
+        ulong seed = id + (ulong)month * (ulong)year;
 
         WordRandomizer wordRandomizer = new(seed);
         


### PR DESCRIPTION
Due to math....... the rank module would generate a seed that has overlaps with 11 of the previous year's seeds.
(`12 + 2023 = 2035`, but so is `11 + 2024`, which meant that the Dec. 2023 rank would appear again in Nov. 2024, and then again in Oct. 2025 and so on.)

By changing the `month + year` to a multiplication gets rid of these overlaps, until Jan. 4048 where Feb. 2024 rank will appear again but who cares about that lol